### PR TITLE
feat: Add http service for fetching data from the API

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useSelector, shallowEqual, useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 
 import Home from './pages/Home';
+import * as api from "./service";
 
 import './App.css';
 
@@ -14,6 +15,11 @@ const App: React.FC = () => {
     (state: AppState) => state.mediaCollection,
     shallowEqual
   );
+
+  React.useEffect(() => {
+    api.getMediaResourceArtistByTerm('iron maiden')
+      .then(console.log);
+  }, []);
 
   return (
     <Home />

--- a/frontend/src/service/index.ts
+++ b/frontend/src/service/index.ts
@@ -1,0 +1,17 @@
+import requester from "./requester";
+
+/*
+ * entities: musicArtist (allArtist), album, mix, song.
+ * attributes: mixTerm, genreIndex, artistTerm, composerTerm, albumTerm, ratingIndex, songTerm
+ */
+
+export const getMediaResourceArtistByTerm = async (searchTerm: string) =>
+  requester().get(`&entity=musicArtist&attribute=artistTerm&term=${encodeURI(searchTerm)}`);
+
+export const getMediaResourceAlbumByTerm = async (searchTerm: string) =>
+  requester().get(`&entity=album&attribute=albumTerm&term=${encodeURI(searchTerm)}`);
+
+export const getMediaResourceSongByTerm = async (searchTerm: string) =>
+  requester().get(`&entity=song&attribute=songTerm&term=${encodeURI(searchTerm)}`);
+
+

--- a/frontend/src/service/requester.ts
+++ b/frontend/src/service/requester.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+/**
+ * Abstraction for the http request library. 
+ */
+const instance = axios.create({
+  baseURL: " https://itunes.apple.com/search?media=music&limit=10",
+  timeout: 1000
+});
+
+function getInstance() {
+  return instance;
+}
+
+export default getInstance;


### PR DESCRIPTION
Included a interface to make AJAX requests throught Axios library. The
use of the third-party library responsible for fetching the data from
the API is hidden and expose throught an abstraction to promote loose
coupling.

Issue: #11