### PR TITLE
feat: add return to search at bottom of results

### DIFF
--- a/frontend/src/components/EndOfResults/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/frontend/src/components/EndOfResults/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders the EndOfResults component 1`] = `
+<p
+  className="MuiBox-root css-xi606m"
+>
+  <span
+    className="MuiBox-root css-0"
+  >
+    End of the results. Jump to the top
+  </span>
+   
+  <button
+    aria-label="Jump to the top"
+    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDragLeave={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    tabIndex={0}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      data-testid="ArrowUpwardIcon"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+      />
+    </svg>
+  </button>
+</p>
+`;

--- a/frontend/src/components/EndOfResults/__tests__/index.spec.tsx
+++ b/frontend/src/components/EndOfResults/__tests__/index.spec.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+import renderer from "react-test-renderer";
+
+import EndOfResults from "../index";
+
+test("renders the EndOfResults component", () => {
+  expect(renderer.create(<EndOfResults />).toJSON()).toMatchSnapshot();
+});

--- a/frontend/src/components/EndOfResults/index.tsx
+++ b/frontend/src/components/EndOfResults/index.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+
+const EndOfResults: React.FC = () => {
+  const clickHandler = () => window.scroll(0, 0);
+  return (
+    <Box component="p" sx={{ textAlign: "center" }}>
+      <Box component="span">End of the results. Jump to the top</Box>{" "}
+      <IconButton
+        color="primary"
+        aria-label="Jump to the top"
+        onClick={clickHandler}
+      >
+        <ArrowUpwardIcon />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default React.memo(EndOfResults);

--- a/frontend/src/components/MediaResourceList/index.tsx
+++ b/frontend/src/components/MediaResourceList/index.tsx
@@ -7,10 +7,11 @@ import Divider from "@mui/material/Divider";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 
+import { fetchLoadResults } from "../../store/actionCreators";
+
 import MediaResourceItem from "../MediaResourceItem";
 import ResultNotFound from "../ResultsNotFound";
-
-import { fetchLoadResults } from "../../store/actionCreators";
+import EndOfResults from "../EndOfResults";
 
 const MediaResourceList: React.FC = React.memo(() => {
   const dispatch: Dispatch<any> = useDispatch();
@@ -63,11 +64,7 @@ const MediaResourceList: React.FC = React.memo(() => {
                 <CircularProgress disableShrink />
               </Box>
             }
-            endMessage={
-              <Box component="p" sx={{ textAlign: "center" }}>
-                <b>End of the results</b>
-              </Box>
-            }
+            endMessage={<EndOfResults />}
           >
             {resources.map((resource: Media, index: number) => (
               <Box key={`${resource.artistId}-${index}`}>

--- a/frontend/src/components/ResultsNotFound/index.tsx
+++ b/frontend/src/components/ResultsNotFound/index.tsx
@@ -6,4 +6,4 @@ const ResultsNotFound: React.FC = () => (
   <Box>You got zero results. Try again changing the term of your search.</Box>
 );
 
-export default ResultsNotFound;
+export default React.memo(ResultsNotFound);


### PR DESCRIPTION
Increase the UX with the option to jump right out to the top from the bottom of the page. Some results are much bigger (more than 100 entries). From the user perspective could be quite annoying to scroll up back again to the top to redoing the search.
Issue: #46